### PR TITLE
Assert on possible divide-by-zero, initialize uninitialized const.

### DIFF
--- a/src/libsphinxbase/feat/agc.c
+++ b/src/libsphinxbase/feat/agc.c
@@ -56,7 +56,7 @@
  * 04-Nov-95	M K Ravishankar (rkm@cs.cmu.edu) at Carnegie Mellon University
  * 		Created.
  */
-
+#include <assert.h>
 #include <string.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -203,6 +203,9 @@ agc_noise(agc_t *agc,
             noise_frames++;
         }
     }
+    
+    assert(noise_frames != 0); /* If (nfr == 0), previous loop won't iterate and noise_frames will be zero when dividing. - HLW */
+    
     noise_level /= noise_frames;
 
     E_INFO("AGC NOISE: max= %6.3f\n", MFCC2FLOAT(noise_level));

--- a/src/sphinx_fe/sphinx_fe.c
+++ b/src/sphinx_fe/sphinx_fe.c
@@ -796,7 +796,7 @@ sphinx_wave2feat_retain(sphinx_wave2feat_t *wtf)
 static audio_type_t const *
 detect_audio_type(sphinx_wave2feat_t *wtf)
 {
-    audio_type_t const *atype;
+    audio_type_t const *atype = NULL;
     int i;
 
     /* Special case audio type for Sphinx MFCC inputs. */


### PR DESCRIPTION
These are my local changes I'm making due to having warnings as errors. I've added an assertion to catch possible divide-by-zero states in agc.c and initialized const *atype in sphinx_fe.c
