### PR TITLE
Fix bug in OSX sdkpath location code when multiple SDKs exist

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -162,7 +162,8 @@ case $host in
 		ad_libs="-lwinmm"
 		;;
 	*-apple-*darwin*)
-		sdkpath=`xcodebuild -version -sdk  | grep MacOSX | grep "^Path:" | cut -d" " -f2`
+		sdkparam=`xcodebuild -showsdks | awk '/^$/{p=0};p; /OS X SDKs:/{p=1}' | tail -1 | cut -f3`
+		sdkpath=`xcodebuild -version $sdkparam Path`
 		ad_cppflags="-I$sdkpath/System/Library/Frameworks/OpenAL.framework/Versions/A/Headers/"
 		backup_CPPFLAGS="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $ad_cppflags"


### PR DESCRIPTION
Not sure how much of an edge case this is, but when two XCode SDKs exist on the same system as was the case for me, the current location code results in, for example:

``` bash
$ sdkpath=`xcodebuild -version -sdk  | grep MacOSX | grep "^Path:" | cut -d" " -f2`
$ echo $sdkpath
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
```

This causes configure to fail with:

``` bash
checking for pthread_create in -lpthread... yes
checking alc.h usability... no
checking alc.h presence... no
checking for alc.h... no
configure: error: OpenAL not found
```

Using some alternative logic suggested [here](http://stackoverflow.com/questions/18741675/how-to-get-the-path-of-latest-sdk-available-on-mac) fixes this problem and selects the latest SDK.
