### PR TITLE
Added logmath_exp support

### DIFF
--- a/swig/logmath.i
+++ b/swig/logmath.i
@@ -48,4 +48,8 @@
     ~LogMath() {
         logmath_free($self);
     }
+    
+    double exp(int prob) {
+        return logmath_exp($self, prob);
+    }
 }


### PR DESCRIPTION
Gives access to `logmath_exp` function to Python wrapper which can be used to convert log-prob back to regular prob with values in range [0,1]