### PR TITLE
Fix for fe_process_frames_ext() not updating global sample_counter in some cases

### DIFF
--- a/src/libsphinxbase/fe/fe_interface.c
+++ b/src/libsphinxbase/fe/fe_interface.c
@@ -471,6 +471,8 @@ fe_process_frames_ext(fe_t *fe,
             memcpy(fe->overflow_samps + fe->num_overflow_samps,
                    *inout_spch, *inout_nsamps * (sizeof(int16)));
             fe->num_overflow_samps += *inout_nsamps;
+            /* Update global sample counter with number of samples */
+            fe->sample_counter += *inout_nsamps;
             /* Update input-output pointers and counters. */
             *inout_spch += *inout_nsamps;
             *inout_nsamps = 0;


### PR DESCRIPTION
This solves issue 50 I've created on pocketsphinx.
https://github.com/cmusphinx/pocketsphinx/issues/50

As noted in title, fe_process_frames_ext() didn't update sample_counter when passed sample buffer that wasn't big enough to fill whole frame. As a consequence ps_seg_frames() in pocketsphinx was returning incorrect frame numbers/text times