### PR TITLE
This change fixes a bug in the sphinx_fe

### DIFF
--- a/src/sphinx_fe/sphinx_fe.c
+++ b/src/sphinx_fe/sphinx_fe.c
@@ -134,7 +134,7 @@ detect_riff(sphinx_wave2feat_t *wtf)
 	return -1;
     }
     if (cmd_ln_float32_r(wtf->config, "-samprate") != hdr.SamplingFreq) {
-	E_ERROR("Sample rate %.1f does not match configured value in file '%s'\n", hdr.SamplingFreq, wtf->infile);
+	E_ERROR("Sample rate %.1f does not match configured value in file '%s'\n", (float)hdr.SamplingFreq, wtf->infile);
 	fclose(fh);
 	return -1;
     }


### PR DESCRIPTION
When printing the error message when sampling rate mismatch, the original
code used %.1f for an integer value, that leads to the program to just
terminate without printing anything.

The fix casted the integer value into a float value, so the program will
print out the error message just fine.