### PR TITLE
Fix a bug in fe_noise's fe_temp_masking

### DIFF
--- a/src/libsphinxbase/fe/fe_noise.c
+++ b/src/libsphinxbase/fe/fe_noise.c
@@ -192,11 +192,11 @@ fe_temp_masking(noise_stats_t *noise_stats, powspec_t * buf, powspec_t * peak, i
 
 #ifndef FIXED_POINT
         peak[i] *= noise_stats->lambda_t;
-        if (buf[i] < noise_stats->lambda_t * peak[i])
+        if (buf[i] < peak[i] * noise_stats->mu_t)
             buf[i] = peak[i] * noise_stats->mu_t;
 #else
         peak[i] += noise_stats->lambda_t;
-        if (buf[i] < noise_stats->lambda_t + peak[i])
+        if (buf[i] < peak[i] + noise_stats->mu_t)
             buf[i] = peak[i] + noise_stats->mu_t;
 #endif
 


### PR DESCRIPTION
Hi, I noticed a piece of weird code, in my opinion, the intended workflow should be as this PR.
Please review it, and if it's right, may I expect a new version for Acoustics Model?
Thanks