### PR TITLE
Swig move_next fix

### DIFF
--- a/swig/iterators.i
+++ b/swig/iterators.i
@@ -127,6 +127,8 @@ typedef struct {} TYPE##Iterator;
   }
 #elif SWIGCSHARP
   bool MoveNext() {
+    if(!$self || !$self->ptr)
+        return false;
     $self->ptr = ##PREFIX##_next($self->ptr);
     if ($self->ptr) {
 	return true;


### PR DESCRIPTION
Fixed swig interface for input. *wav with silence and iterating over segments over results in csharp code:

`foreach (Segment segment in decoder.Seg())
{
     //do something
}`

Example wav in attachment
[silence.zip](https://github.com/cmusphinx/sphinxbase/files/1296904/silence.zip)
 