### PR TITLE
Fixed sphinxbase.pc libs syntax

### DIFF
--- a/sphinxbase.pc.in
+++ b/sphinxbase.pc.in
@@ -2,7 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-libs="@LIBS@"
+libs=@LIBS@
 datadir=@datarootdir@/@PACKAGE@
 
 Name: SphinxBase


### PR DESCRIPTION
Removed quotes around libs variable. Invoking pkgconf --static --libs sphinxbase would output:
```
-lsphinxbase -lsphinxad -lpulse -lpulse-simple -lpthread -lm -lblas -llapack -lpulse\ -lpulse-simple\ -lpthread\ -lm\ -lblas\ -llapack\  
```
instead of:
```
-lsphinxbase -lsphinxad -lpulse -lpulse-simple -lpthread -lm -lblas -llapack -lpulse -lpulse-simple -lpthread -lm -lblas -llapack
```