### PR TITLE
pulseaudio open device sample rate fix

### DIFF
--- a/src/libsphinxad/ad_pulse.c
+++ b/src/libsphinxad/ad_pulse.c
@@ -66,7 +66,7 @@ ad_open_dev(const char *dev, int32 samples_per_sec)
 
     ss.format = PA_SAMPLE_S16LE;
     ss.channels = 1;
-    ss.rate = 16000;
+    ss.rate = samples_per_sec;
     
     pa = pa_simple_new(NULL, "ASR", PA_STREAM_RECORD, dev, "Speech", &ss, NULL, NULL, &error);
     if (pa == NULL) {


### PR DESCRIPTION
Despite provided sample rate, pulseaudio device was opened
with rate of 16000, which was hardcoded.

Signed-off-by: morethanuser <hardware.coder@gmail.com>