### PR TITLE
Python3: Fix swig module import

### DIFF
--- a/swig/python/__init__.py
+++ b/swig/python/__init__.py
@@ -34,4 +34,4 @@
 # ====================================================================
 
 
-from sphinxbase import *
+from .sphinxbase import *


### PR DESCRIPTION
Python3 uses absolute imports, so "from sphinxbase import *" does nothing as it thinks it wants to import the current module (the sphinxbase directory with the __init__py in it, not the sphinxbase.py swig module).

You can try this for yourself on this example:
```
$ mkdir foo
$ echo "from foo import *" > foo/__init__.py
$ echo "print('import ok')" > foo/foo.py
$ python2 -c "import foo"
import ok
$ python3 -c "import foo"
$ <== [no output, foo.py is not imported]
```

now use a relative import:
```
$ echo "from .foo import *" > foo/__init__.py
$ python2 -c "import foo"
import ok
$ python3 -c "import foo"
import ok
```


I successfully fixed the import of sphinxbase and pocketsphinx using this fix, tested on python2 & python3:
```
# echo N | sudo tee /sys/module/overlay/parameters/metacopy
FROM ubuntu:bionic
MAINTAINER jschueller
ENV MAKEFLAGS "-j4"
ENV TERM dumb
WORKDIR /tmp
RUN apt-get -y update
RUN apt-get install -y git swig python-dev python3-dev liblapack-dev sudo bison autoconf automake libtool make
RUN useradd -m -d /home/ubuntu -u 1000 -U -G users,tty -s /bin/bash ubuntu
RUN echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
USER ubuntu

RUN git clone --depth 1 https://github.com/cmusphinx/sphinxbase.git && cd sphinxbase && sed -i "s|from sphinxbase|from .sphinxbase|g" swig/python/__init__.py && autoreconf -i && mkdir py2 && cd py2 && ../configure --prefix=/home/ubuntu/.local && make && make install && cd .. && mkdir py3 && cd py3 && PYTHON=/usr/bin/python3 ../configure --prefix=/home/ubuntu/.local && make && make install
RUN python2 -c "from sphinxbase import LogMath; print(LogMath().exp(3))"
RUN python3 -c "from sphinxbase import LogMath; print(LogMath().exp(3))"

RUN   find   /home/ubuntu/.local -name sphinxbase.i

RUN git clone --depth 1 https://github.com/cmusphinx/pocketsphinx.git && cd pocketsphinx && sed -i "s|from pocketsphinx|from pocketsphinx|g" swig/python/__init__.py && autoreconf -i && mkdir py2 && cd py2 &&  ../configure --with-sphinxbase=/home/ubuntu/.local/ --prefix=/home/ubuntu/.local && make SWIG_FLAGS="-I/home/ubuntu/.local/share/sphinxbase/swig" && make install && cd .. && mkdir py3 && cd py3 && PYTHON=/usr/bin/python3 ../configure --with-sphinxbase=/home/ubuntu/.local/ --prefix=/home/ubuntu/.local && make SWIG_FLAGS="-I/home/ubuntu/.local/share/sphinxbase/swig" && make install
RUN echo "print('youyou')" >> /home/ubuntu/.local/lib/python3.6/site-packages/pocketsphinx/__init__.py
RUN python3 -c "import pocketsphinx; print(pocketsphinx.__file__)"

RUN python2 -c "from pocketsphinx import Decoder; config = Decoder.default_config()"
RUN python3 -c "from pocketsphinx import Decoder; config = Decoder.default_config()"
```








