### PR TITLE
Add missing bracket to C++ extern statement in yin.h

### DIFF
--- a/include/sphinxbase/yin.h
+++ b/include/sphinxbase/yin.h
@@ -43,7 +43,7 @@
 #define __YIN_H__
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 #if 0
 } /* Fool Emacs. */


### PR DESCRIPTION
This file didn't actually compile in C++ because the opening bracket on this line was missing. I checked every other instance of 'extern \"C\"' in the tree and this seems to be the only one with this particular problem.