### PR TITLE
Add const to query functions for cmd_ln_t and logmath_t

### DIFF
--- a/include/sphinxbase/cmd_ln.h
+++ b/include/sphinxbase/cmd_ln.h
@@ -264,7 +264,7 @@ cmd_ln_t *cmd_ln_parse_file_r(cmd_ln_t *inout_cmdln, /**< In/Out: Previous comma
  * Access the generic type union for a command line argument.
  */
 SPHINXBASE_EXPORT
-anytype_t *cmd_ln_access_r(const cmd_ln_t *cmdln, char const *name);
+anytype_t *cmd_ln_access_r(cmd_ln_t const *cmdln, char const *name);
 
 /**
  * Retrieve a string from a command-line object.
@@ -281,7 +281,7 @@ anytype_t *cmd_ln_access_r(const cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-char const *cmd_ln_str_r(const cmd_ln_t *cmdln, char const *name);
+char const *cmd_ln_str_r(cmd_ln_t const *cmdln, char const *name);
 
 /**
  * Retrieve an array of strings from a command-line object.
@@ -298,7 +298,7 @@ char const *cmd_ln_str_r(const cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-char const **cmd_ln_str_list_r(const cmd_ln_t *cmdln, char const *name);
+char const **cmd_ln_str_list_r(cmd_ln_t const *cmdln, char const *name);
 
 /**
  * Retrieve an integer from a command-line object.
@@ -312,7 +312,7 @@ char const **cmd_ln_str_list_r(const cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-long cmd_ln_int_r(const cmd_ln_t *cmdln, char const *name);
+long cmd_ln_int_r(cmd_ln_t const *cmdln, char const *name);
 
 /**
  * Retrieve a floating-point number from a command-line object.
@@ -326,7 +326,7 @@ long cmd_ln_int_r(const cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-double cmd_ln_float_r(const cmd_ln_t *cmdln, char const *name);
+double cmd_ln_float_r(cmd_ln_t const *cmdln, char const *name);
 
 /**
  * Retrieve a boolean value from a command-line object.
@@ -399,7 +399,7 @@ void cmd_ln_set_float_r(cmd_ln_t *cmdln, char const *name, double fv);
  * was one of the arguments defined in the call to cmd_ln_parse_r().
  */
 SPHINXBASE_EXPORT
-int cmd_ln_exists_r(const cmd_ln_t *cmdln, char const *name);
+int cmd_ln_exists_r(cmd_ln_t const *cmdln, char const *name);
 
 /**
  * Print a help message listing the valid argument names, and the associated
@@ -410,7 +410,7 @@ int cmd_ln_exists_r(const cmd_ln_t *cmdln, char const *name);
  * @param defn array of argument name definitions.
  */
 SPHINXBASE_EXPORT
-void cmd_ln_print_help_r (const cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
+void cmd_ln_print_help_r (cmd_ln_t const *cmdln, FILE *fp, const arg_t *defn);
 
 /**
  * Print current configuration values and defaults.
@@ -420,7 +420,7 @@ void cmd_ln_print_help_r (const cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
  * @param defn array of argument name definitions.
  */
 SPHINXBASE_EXPORT
-void cmd_ln_print_values_r (const cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
+void cmd_ln_print_values_r (cmd_ln_t const *cmdln, FILE *fp, const arg_t *defn);
 
 /**
  * Non-reentrant version of cmd_ln_parse().

--- a/include/sphinxbase/cmd_ln.h
+++ b/include/sphinxbase/cmd_ln.h
@@ -264,7 +264,7 @@ cmd_ln_t *cmd_ln_parse_file_r(cmd_ln_t *inout_cmdln, /**< In/Out: Previous comma
  * Access the generic type union for a command line argument.
  */
 SPHINXBASE_EXPORT
-anytype_t *cmd_ln_access_r(cmd_ln_t *cmdln, char const *name);
+anytype_t *cmd_ln_access_r(const cmd_ln_t *cmdln, char const *name);
 
 /**
  * Retrieve a string from a command-line object.
@@ -281,7 +281,7 @@ anytype_t *cmd_ln_access_r(cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-char const *cmd_ln_str_r(cmd_ln_t *cmdln, char const *name);
+char const *cmd_ln_str_r(const cmd_ln_t *cmdln, char const *name);
 
 /**
  * Retrieve an array of strings from a command-line object.
@@ -298,7 +298,7 @@ char const *cmd_ln_str_r(cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-char const **cmd_ln_str_list_r(cmd_ln_t *cmdln, char const *name);
+char const **cmd_ln_str_list_r(const cmd_ln_t *cmdln, char const *name);
 
 /**
  * Retrieve an integer from a command-line object.
@@ -312,7 +312,7 @@ char const **cmd_ln_str_list_r(cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-long cmd_ln_int_r(cmd_ln_t *cmdln, char const *name);
+long cmd_ln_int_r(const cmd_ln_t *cmdln, char const *name);
 
 /**
  * Retrieve a floating-point number from a command-line object.
@@ -326,7 +326,7 @@ long cmd_ln_int_r(cmd_ln_t *cmdln, char const *name);
  *         is unknown.
  */
 SPHINXBASE_EXPORT
-double cmd_ln_float_r(cmd_ln_t *cmdln, char const *name);
+double cmd_ln_float_r(const cmd_ln_t *cmdln, char const *name);
 
 /**
  * Retrieve a boolean value from a command-line object.
@@ -399,7 +399,7 @@ void cmd_ln_set_float_r(cmd_ln_t *cmdln, char const *name, double fv);
  * was one of the arguments defined in the call to cmd_ln_parse_r().
  */
 SPHINXBASE_EXPORT
-int cmd_ln_exists_r(cmd_ln_t *cmdln, char const *name);
+int cmd_ln_exists_r(const cmd_ln_t *cmdln, char const *name);
 
 /**
  * Print a help message listing the valid argument names, and the associated
@@ -410,7 +410,7 @@ int cmd_ln_exists_r(cmd_ln_t *cmdln, char const *name);
  * @param defn array of argument name definitions.
  */
 SPHINXBASE_EXPORT
-void cmd_ln_print_help_r (cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
+void cmd_ln_print_help_r (const cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
 
 /**
  * Print current configuration values and defaults.
@@ -420,7 +420,7 @@ void cmd_ln_print_help_r (cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
  * @param defn array of argument name definitions.
  */
 SPHINXBASE_EXPORT
-void cmd_ln_print_values_r (cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
+void cmd_ln_print_values_r (const cmd_ln_t *cmdln, FILE *fp, const arg_t *defn);
 
 /**
  * Non-reentrant version of cmd_ln_parse().

--- a/include/sphinxbase/logmath.h
+++ b/include/sphinxbase/logmath.h
@@ -132,38 +132,38 @@ logmath_t *logmath_read(const char *filename);
  * Write a log table to a file.
  */
 SPHINXBASE_EXPORT
-int32 logmath_write(logmath_t *lmath, const char *filename);
+int32 logmath_write(const logmath_t *lmath, const char *filename);
 
 /**
  * Get the log table size and dimensions.
  */
 SPHINXBASE_EXPORT
-int32 logmath_get_table_shape(logmath_t *lmath, uint32 *out_size,
+int32 logmath_get_table_shape(const logmath_t *lmath, uint32 *out_size,
                               uint32 *out_width, uint32 *out_shift);
 
 /**
  * Get the log base.
  */
 SPHINXBASE_EXPORT
-float64 logmath_get_base(logmath_t *lmath);
+float64 logmath_get_base(const logmath_t *lmath);
 
 /**
  * Get the smallest possible value represented in this base.
  */
 SPHINXBASE_EXPORT
-int logmath_get_zero(logmath_t *lmath);
+int logmath_get_zero(const logmath_t *lmath);
 
 /**
  * Get the width of the values in a log table.
  */
 SPHINXBASE_EXPORT
-int logmath_get_width(logmath_t *lmath);
+int logmath_get_width(const logmath_t *lmath);
 
 /**
  * Get the shift of the values in a log table.
  */
 SPHINXBASE_EXPORT
-int logmath_get_shift(logmath_t *lmath);
+int logmath_get_shift(const logmath_t *lmath);
 
 /**
  * Retain ownership of a log table.
@@ -185,61 +185,61 @@ int logmath_free(logmath_t *lmath);
  * Add two values in log space exactly and slowly (without using add table).
  */
 SPHINXBASE_EXPORT
-int logmath_add_exact(logmath_t *lmath, int logb_p, int logb_q);
+int logmath_add_exact(const logmath_t *lmath, int logb_p, int logb_q);
 
 /**
  * Add two values in log space (i.e. return log(exp(p)+exp(q)))
  */
 SPHINXBASE_EXPORT
-int logmath_add(logmath_t *lmath, int logb_p, int logb_q);
+int logmath_add(const logmath_t *lmath, int logb_p, int logb_q);
 
 /**
  * Convert linear floating point number to integer log in base B.
  */
 SPHINXBASE_EXPORT
-int logmath_log(logmath_t *lmath, float64 p);
+int logmath_log(const logmath_t *lmath, float64 p);
 
 /**
  * Convert integer log in base B to linear floating point.
  */
 SPHINXBASE_EXPORT
-float64 logmath_exp(logmath_t *lmath, int logb_p);
+float64 logmath_exp(const logmath_t *lmath, int logb_p);
 
 /**
  * Convert natural log (in floating point) to integer log in base B.
  */
 SPHINXBASE_EXPORT
-int logmath_ln_to_log(logmath_t *lmath, float64 log_p);
+int logmath_ln_to_log(const logmath_t *lmath, float64 log_p);
 
 /**
  * Convert integer log in base B to natural log (in floating point).
  */
 SPHINXBASE_EXPORT
-float64 logmath_log_to_ln(logmath_t *lmath, int logb_p);
+float64 logmath_log_to_ln(const logmath_t *lmath, int logb_p);
 
 /**
  * Convert base 10 log (in floating point) to integer log in base B.
  */
 SPHINXBASE_EXPORT
-int logmath_log10_to_log(logmath_t *lmath, float64 log_p);
+int logmath_log10_to_log(const logmath_t *lmath, float64 log_p);
 
 /**
  * Convert base 10 log (in floating point) to float log in base B.
  */
 SPHINXBASE_EXPORT
-float logmath_log10_to_log_float(logmath_t *lmath, float64 log_p);
+float logmath_log10_to_log_float(const logmath_t *lmath, float64 log_p);
 
 /**
  * Convert integer log in base B to base 10 log (in floating point).
  */
 SPHINXBASE_EXPORT
-float64 logmath_log_to_log10(logmath_t *lmath, int logb_p);
+float64 logmath_log_to_log10(const logmath_t *lmath, int logb_p);
 
 /**
  * Convert float log in base B to base 10 log.
  */
 SPHINXBASE_EXPORT
-float64 logmath_log_float_to_log10(logmath_t *lmath, float log_p);
+float64 logmath_log_float_to_log10(const logmath_t *lmath, float log_p);
 
 #ifdef __cplusplus
 }

--- a/include/sphinxbase/logmath.h
+++ b/include/sphinxbase/logmath.h
@@ -132,38 +132,38 @@ logmath_t *logmath_read(const char *filename);
  * Write a log table to a file.
  */
 SPHINXBASE_EXPORT
-int32 logmath_write(const logmath_t *lmath, const char *filename);
+int32 logmath_write(logmath_t const *lmath, const char *filename);
 
 /**
  * Get the log table size and dimensions.
  */
 SPHINXBASE_EXPORT
-int32 logmath_get_table_shape(const logmath_t *lmath, uint32 *out_size,
+int32 logmath_get_table_shape(logmath_t const *lmath, uint32 *out_size,
                               uint32 *out_width, uint32 *out_shift);
 
 /**
  * Get the log base.
  */
 SPHINXBASE_EXPORT
-float64 logmath_get_base(const logmath_t *lmath);
+float64 logmath_get_base(logmath_t const *lmath);
 
 /**
  * Get the smallest possible value represented in this base.
  */
 SPHINXBASE_EXPORT
-int logmath_get_zero(const logmath_t *lmath);
+int logmath_get_zero(logmath_t const *lmath);
 
 /**
  * Get the width of the values in a log table.
  */
 SPHINXBASE_EXPORT
-int logmath_get_width(const logmath_t *lmath);
+int logmath_get_width(logmath_t const *lmath);
 
 /**
  * Get the shift of the values in a log table.
  */
 SPHINXBASE_EXPORT
-int logmath_get_shift(const logmath_t *lmath);
+int logmath_get_shift(logmath_t const *lmath);
 
 /**
  * Retain ownership of a log table.
@@ -185,61 +185,61 @@ int logmath_free(logmath_t *lmath);
  * Add two values in log space exactly and slowly (without using add table).
  */
 SPHINXBASE_EXPORT
-int logmath_add_exact(const logmath_t *lmath, int logb_p, int logb_q);
+int logmath_add_exact(logmath_t const *lmath, int logb_p, int logb_q);
 
 /**
  * Add two values in log space (i.e. return log(exp(p)+exp(q)))
  */
 SPHINXBASE_EXPORT
-int logmath_add(const logmath_t *lmath, int logb_p, int logb_q);
+int logmath_add(logmath_t const *lmath, int logb_p, int logb_q);
 
 /**
  * Convert linear floating point number to integer log in base B.
  */
 SPHINXBASE_EXPORT
-int logmath_log(const logmath_t *lmath, float64 p);
+int logmath_log(logmath_t const *lmath, float64 p);
 
 /**
  * Convert integer log in base B to linear floating point.
  */
 SPHINXBASE_EXPORT
-float64 logmath_exp(const logmath_t *lmath, int logb_p);
+float64 logmath_exp(logmath_t const *lmath, int logb_p);
 
 /**
  * Convert natural log (in floating point) to integer log in base B.
  */
 SPHINXBASE_EXPORT
-int logmath_ln_to_log(const logmath_t *lmath, float64 log_p);
+int logmath_ln_to_log(logmath_t const *lmath, float64 log_p);
 
 /**
  * Convert integer log in base B to natural log (in floating point).
  */
 SPHINXBASE_EXPORT
-float64 logmath_log_to_ln(const logmath_t *lmath, int logb_p);
+float64 logmath_log_to_ln(logmath_t const *lmath, int logb_p);
 
 /**
  * Convert base 10 log (in floating point) to integer log in base B.
  */
 SPHINXBASE_EXPORT
-int logmath_log10_to_log(const logmath_t *lmath, float64 log_p);
+int logmath_log10_to_log(logmath_t const *lmath, float64 log_p);
 
 /**
  * Convert base 10 log (in floating point) to float log in base B.
  */
 SPHINXBASE_EXPORT
-float logmath_log10_to_log_float(const logmath_t *lmath, float64 log_p);
+float logmath_log10_to_log_float(logmath_t const *lmath, float64 log_p);
 
 /**
  * Convert integer log in base B to base 10 log (in floating point).
  */
 SPHINXBASE_EXPORT
-float64 logmath_log_to_log10(const logmath_t *lmath, int logb_p);
+float64 logmath_log_to_log10(logmath_t const *lmath, int logb_p);
 
 /**
  * Convert float log in base B to base 10 log.
  */
 SPHINXBASE_EXPORT
-float64 logmath_log_float_to_log10(const logmath_t *lmath, float log_p);
+float64 logmath_log_float_to_log10(logmath_t const *lmath, float log_p);
 
 #ifdef __cplusplus
 }

--- a/src/libsphinxbase/util/cmd_ln.c
+++ b/src/libsphinxbase/util/cmd_ln.c
@@ -99,7 +99,7 @@ struct cmd_ln_s {
 cmd_ln_t *global_cmdln;
 
 static void
-arg_dump_r(const cmd_ln_t *, FILE *, arg_t const *, int32);
+arg_dump_r(cmd_ln_t const *, FILE *, arg_t const *, int32);
 
 static cmd_ln_t *
 parse_options(cmd_ln_t *, const arg_t *, int32, char* [], int32);
@@ -239,7 +239,7 @@ arg_resolve_env(const char *str)
 }
 
 static void
-arg_dump_r(const cmd_ln_t *cmdln, FILE *fp, const arg_t * defn, int32 doc)
+arg_dump_r(cmd_ln_t const *cmdln, FILE *fp, const arg_t * defn, int32 doc)
 {
     arg_t const **pos;
     int32 i, n;
@@ -908,7 +908,7 @@ cmd_ln_parse_file(const arg_t * defn, const char *filename, int32 strict)
 }
 
 void
-cmd_ln_print_help_r(const cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
+cmd_ln_print_help_r(cmd_ln_t const *cmdln, FILE *fp, arg_t const* defn)
 {
     if (defn == NULL)
         return;
@@ -917,7 +917,7 @@ cmd_ln_print_help_r(const cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
 }
 
 void
-cmd_ln_print_values_r(const cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
+cmd_ln_print_values_r(cmd_ln_t const *cmdln, FILE *fp, arg_t const* defn)
 {
     if (defn == NULL)
         return;
@@ -926,7 +926,7 @@ cmd_ln_print_values_r(const cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
 }
 
 int
-cmd_ln_exists_r(const cmd_ln_t *cmdln, const char *name)
+cmd_ln_exists_r(cmd_ln_t const *cmdln, const char *name)
 {
     void *val;
     if (cmdln == NULL)
@@ -935,7 +935,7 @@ cmd_ln_exists_r(const cmd_ln_t *cmdln, const char *name)
 }
 
 anytype_t *
-cmd_ln_access_r(const cmd_ln_t *cmdln, const char *name)
+cmd_ln_access_r(cmd_ln_t const *cmdln, const char *name)
 {
     void *val;
     if (hash_table_lookup(cmdln->ht, name, &val) < 0) {
@@ -946,7 +946,7 @@ cmd_ln_access_r(const cmd_ln_t *cmdln, const char *name)
 }
 
 char const *
-cmd_ln_str_r(const cmd_ln_t *cmdln, char const *name)
+cmd_ln_str_r(cmd_ln_t const *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);
@@ -956,7 +956,7 @@ cmd_ln_str_r(const cmd_ln_t *cmdln, char const *name)
 }
 
 char const **
-cmd_ln_str_list_r(const cmd_ln_t *cmdln, char const *name)
+cmd_ln_str_list_r(cmd_ln_t const *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);
@@ -966,7 +966,7 @@ cmd_ln_str_list_r(const cmd_ln_t *cmdln, char const *name)
 }
 
 long
-cmd_ln_int_r(const cmd_ln_t *cmdln, char const *name)
+cmd_ln_int_r(cmd_ln_t const *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);
@@ -976,7 +976,7 @@ cmd_ln_int_r(const cmd_ln_t *cmdln, char const *name)
 }
 
 double
-cmd_ln_float_r(const cmd_ln_t *cmdln, char const *name)
+cmd_ln_float_r(cmd_ln_t const *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);

--- a/src/libsphinxbase/util/cmd_ln.c
+++ b/src/libsphinxbase/util/cmd_ln.c
@@ -99,7 +99,7 @@ struct cmd_ln_s {
 cmd_ln_t *global_cmdln;
 
 static void
-arg_dump_r(cmd_ln_t *, FILE *, arg_t const *, int32);
+arg_dump_r(const cmd_ln_t *, FILE *, arg_t const *, int32);
 
 static cmd_ln_t *
 parse_options(cmd_ln_t *, const arg_t *, int32, char* [], int32);
@@ -239,7 +239,7 @@ arg_resolve_env(const char *str)
 }
 
 static void
-arg_dump_r(cmd_ln_t *cmdln, FILE *fp, const arg_t * defn, int32 doc)
+arg_dump_r(const cmd_ln_t *cmdln, FILE *fp, const arg_t * defn, int32 doc)
 {
     arg_t const **pos;
     int32 i, n;
@@ -908,7 +908,7 @@ cmd_ln_parse_file(const arg_t * defn, const char *filename, int32 strict)
 }
 
 void
-cmd_ln_print_help_r(cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
+cmd_ln_print_help_r(const cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
 {
     if (defn == NULL)
         return;
@@ -917,7 +917,7 @@ cmd_ln_print_help_r(cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
 }
 
 void
-cmd_ln_print_values_r(cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
+cmd_ln_print_values_r(const cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
 {
     if (defn == NULL)
         return;
@@ -926,7 +926,7 @@ cmd_ln_print_values_r(cmd_ln_t *cmdln, FILE *fp, arg_t const* defn)
 }
 
 int
-cmd_ln_exists_r(cmd_ln_t *cmdln, const char *name)
+cmd_ln_exists_r(const cmd_ln_t *cmdln, const char *name)
 {
     void *val;
     if (cmdln == NULL)
@@ -935,7 +935,7 @@ cmd_ln_exists_r(cmd_ln_t *cmdln, const char *name)
 }
 
 anytype_t *
-cmd_ln_access_r(cmd_ln_t *cmdln, const char *name)
+cmd_ln_access_r(const cmd_ln_t *cmdln, const char *name)
 {
     void *val;
     if (hash_table_lookup(cmdln->ht, name, &val) < 0) {
@@ -946,7 +946,7 @@ cmd_ln_access_r(cmd_ln_t *cmdln, const char *name)
 }
 
 char const *
-cmd_ln_str_r(cmd_ln_t *cmdln, char const *name)
+cmd_ln_str_r(const cmd_ln_t *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);
@@ -956,7 +956,7 @@ cmd_ln_str_r(cmd_ln_t *cmdln, char const *name)
 }
 
 char const **
-cmd_ln_str_list_r(cmd_ln_t *cmdln, char const *name)
+cmd_ln_str_list_r(const cmd_ln_t *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);
@@ -966,7 +966,7 @@ cmd_ln_str_list_r(cmd_ln_t *cmdln, char const *name)
 }
 
 long
-cmd_ln_int_r(cmd_ln_t *cmdln, char const *name)
+cmd_ln_int_r(const cmd_ln_t *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);
@@ -976,7 +976,7 @@ cmd_ln_int_r(cmd_ln_t *cmdln, char const *name)
 }
 
 double
-cmd_ln_float_r(cmd_ln_t *cmdln, char const *name)
+cmd_ln_float_r(const cmd_ln_t *cmdln, char const *name)
 {
     anytype_t *val;
     val = cmd_ln_access_r(cmdln, name);

--- a/src/libsphinxbase/util/logmath.c
+++ b/src/libsphinxbase/util/logmath.c
@@ -269,7 +269,7 @@ error_out:
 }
 
 int32
-logmath_write(const logmath_t *lmath, const char *file_name)
+logmath_write(logmath_t const *lmath, const char *file_name)
 {
     FILE *fp;
     long pos;
@@ -354,7 +354,7 @@ logmath_free(logmath_t *lmath)
 }
 
 int32
-logmath_get_table_shape(const logmath_t *lmath, uint32 *out_size,
+logmath_get_table_shape(logmath_t const *lmath, uint32 *out_size,
                         uint32 *out_width, uint32 *out_shift)
 {
     if (out_size) *out_size = lmath->t.table_size;
@@ -365,31 +365,31 @@ logmath_get_table_shape(const logmath_t *lmath, uint32 *out_size,
 }
 
 float64
-logmath_get_base(const logmath_t *lmath)
+logmath_get_base(logmath_t const *lmath)
 {
     return lmath->base;
 }
 
 int
-logmath_get_zero(const logmath_t *lmath)
+logmath_get_zero(logmath_t const *lmath)
 {
     return lmath->zero;
 }
 
 int
-logmath_get_width(const logmath_t *lmath)
+logmath_get_width(logmath_t const *lmath)
 {
     return lmath->t.width;
 }
 
 int
-logmath_get_shift(const logmath_t *lmath)
+logmath_get_shift(logmath_t const *lmath)
 {
     return lmath->t.shift;
 }
 
 int
-logmath_add(const logmath_t *lmath, int logb_x, int logb_y)
+logmath_add(logmath_t const *lmath, int logb_x, int logb_y)
 {
     logadd_t *t = LOGMATH_TABLE(lmath);
     int d, r;
@@ -436,7 +436,7 @@ logmath_add(const logmath_t *lmath, int logb_x, int logb_y)
 }
 
 int
-logmath_add_exact(const logmath_t *lmath, int logb_p, int logb_q)
+logmath_add_exact(logmath_t const *lmath, int logb_p, int logb_q)
 {
     return logmath_log(lmath,
                        logmath_exp(lmath, logb_p)
@@ -444,7 +444,7 @@ logmath_add_exact(const logmath_t *lmath, int logb_p, int logb_q)
 }
 
 int
-logmath_log(const logmath_t *lmath, float64 p)
+logmath_log(logmath_t const *lmath, float64 p)
 {
     if (p <= 0) {
         return lmath->zero;
@@ -453,31 +453,31 @@ logmath_log(const logmath_t *lmath, float64 p)
 }
 
 float64
-logmath_exp(const logmath_t *lmath, int logb_p)
+logmath_exp(logmath_t const *lmath, int logb_p)
 {
     return pow(lmath->base, (float64)(logb_p << lmath->t.shift));
 }
 
 int
-logmath_ln_to_log(const logmath_t *lmath, float64 log_p)
+logmath_ln_to_log(logmath_t const *lmath, float64 log_p)
 {
     return (int)(log_p * lmath->inv_log_of_base) >> lmath->t.shift;
 }
 
 float64
-logmath_log_to_ln(const logmath_t *lmath, int logb_p)
+logmath_log_to_ln(logmath_t const *lmath, int logb_p)
 {
     return (float64)(logb_p << lmath->t.shift) * lmath->log_of_base;
 }
 
 int
-logmath_log10_to_log(const logmath_t *lmath, float64 log_p)
+logmath_log10_to_log(logmath_t const *lmath, float64 log_p)
 {
     return (int)(log_p * lmath->inv_log10_of_base) >> lmath->t.shift;
 }
 
 float 
-logmath_log10_to_log_float(const logmath_t *lmath, float64 log_p)
+logmath_log10_to_log_float(logmath_t const *lmath, float64 log_p)
 {
     int i;
     float res = (float)(log_p * lmath->inv_log10_of_base);
@@ -487,13 +487,13 @@ logmath_log10_to_log_float(const logmath_t *lmath, float64 log_p)
 }
 
 float64
-logmath_log_to_log10(const logmath_t *lmath, int logb_p)
+logmath_log_to_log10(logmath_t const *lmath, int logb_p)
 {
     return (float64)(logb_p << lmath->t.shift) * lmath->log10_of_base;
 }
 
 float64
-logmath_log_float_to_log10(const logmath_t *lmath, float log_p)
+logmath_log_float_to_log10(logmath_t const *lmath, float log_p)
 {
     int i;
     for (i = 0; i < lmath->t.shift; i++) {

--- a/src/libsphinxbase/util/logmath.c
+++ b/src/libsphinxbase/util/logmath.c
@@ -269,7 +269,7 @@ error_out:
 }
 
 int32
-logmath_write(logmath_t *lmath, const char *file_name)
+logmath_write(const logmath_t *lmath, const char *file_name)
 {
     FILE *fp;
     long pos;
@@ -354,7 +354,7 @@ logmath_free(logmath_t *lmath)
 }
 
 int32
-logmath_get_table_shape(logmath_t *lmath, uint32 *out_size,
+logmath_get_table_shape(const logmath_t *lmath, uint32 *out_size,
                         uint32 *out_width, uint32 *out_shift)
 {
     if (out_size) *out_size = lmath->t.table_size;
@@ -365,31 +365,31 @@ logmath_get_table_shape(logmath_t *lmath, uint32 *out_size,
 }
 
 float64
-logmath_get_base(logmath_t *lmath)
+logmath_get_base(const logmath_t *lmath)
 {
     return lmath->base;
 }
 
 int
-logmath_get_zero(logmath_t *lmath)
+logmath_get_zero(const logmath_t *lmath)
 {
     return lmath->zero;
 }
 
 int
-logmath_get_width(logmath_t *lmath)
+logmath_get_width(const logmath_t *lmath)
 {
     return lmath->t.width;
 }
 
 int
-logmath_get_shift(logmath_t *lmath)
+logmath_get_shift(const logmath_t *lmath)
 {
     return lmath->t.shift;
 }
 
 int
-logmath_add(logmath_t *lmath, int logb_x, int logb_y)
+logmath_add(const logmath_t *lmath, int logb_x, int logb_y)
 {
     logadd_t *t = LOGMATH_TABLE(lmath);
     int d, r;
@@ -436,7 +436,7 @@ logmath_add(logmath_t *lmath, int logb_x, int logb_y)
 }
 
 int
-logmath_add_exact(logmath_t *lmath, int logb_p, int logb_q)
+logmath_add_exact(const logmath_t *lmath, int logb_p, int logb_q)
 {
     return logmath_log(lmath,
                        logmath_exp(lmath, logb_p)
@@ -444,7 +444,7 @@ logmath_add_exact(logmath_t *lmath, int logb_p, int logb_q)
 }
 
 int
-logmath_log(logmath_t *lmath, float64 p)
+logmath_log(const logmath_t *lmath, float64 p)
 {
     if (p <= 0) {
         return lmath->zero;
@@ -453,31 +453,31 @@ logmath_log(logmath_t *lmath, float64 p)
 }
 
 float64
-logmath_exp(logmath_t *lmath, int logb_p)
+logmath_exp(const logmath_t *lmath, int logb_p)
 {
     return pow(lmath->base, (float64)(logb_p << lmath->t.shift));
 }
 
 int
-logmath_ln_to_log(logmath_t *lmath, float64 log_p)
+logmath_ln_to_log(const logmath_t *lmath, float64 log_p)
 {
     return (int)(log_p * lmath->inv_log_of_base) >> lmath->t.shift;
 }
 
 float64
-logmath_log_to_ln(logmath_t *lmath, int logb_p)
+logmath_log_to_ln(const logmath_t *lmath, int logb_p)
 {
     return (float64)(logb_p << lmath->t.shift) * lmath->log_of_base;
 }
 
 int
-logmath_log10_to_log(logmath_t *lmath, float64 log_p)
+logmath_log10_to_log(const logmath_t *lmath, float64 log_p)
 {
     return (int)(log_p * lmath->inv_log10_of_base) >> lmath->t.shift;
 }
 
 float 
-logmath_log10_to_log_float(logmath_t *lmath, float64 log_p)
+logmath_log10_to_log_float(const logmath_t *lmath, float64 log_p)
 {
     int i;
     float res = (float)(log_p * lmath->inv_log10_of_base);
@@ -487,13 +487,13 @@ logmath_log10_to_log_float(logmath_t *lmath, float64 log_p)
 }
 
 float64
-logmath_log_to_log10(logmath_t *lmath, int logb_p)
+logmath_log_to_log10(const logmath_t *lmath, int logb_p)
 {
     return (float64)(logb_p << lmath->t.shift) * lmath->log10_of_base;
 }
 
 float64
-logmath_log_float_to_log10(logmath_t *lmath, float log_p)
+logmath_log_float_to_log10(const logmath_t *lmath, float log_p)
 {
     int i;
     for (i = 0; i < lmath->t.shift; i++) {


### PR DESCRIPTION
Most of the functions in both of these classes can be `const`, allowing client code to be more careful about const correctness.

Unfortunately the existence of the `refcount` member variable means that many applications will not be able to use these structs entirely as `const`, but this change makes it easier to pass them to functions without breaking anything.