### PR TITLE
Update Public Header in prim_type.h

### DIFF
--- a/include/sphinxbase/prim_type.h
+++ b/include/sphinxbase/prim_type.h
@@ -85,7 +85,7 @@ extern "C" {
 } /* Fool Emacs into not indenting things. */
 #endif
 
-#include <sphinx_config.h>
+#include <sphinxbase/sphinx_config.h>
 
 /* Define some things for VisualDSP++ */
 #if defined(__ADSPBLACKFIN__) && !defined(__GNUC__)


### PR DESCRIPTION
Hello!

I tried importing sphinxbase `sphinxbase/fe.h` into a macOS project, but it was complaining about this header. I noticed it was not relative to the project like the other includes, so I updated it, and the project compiled successfully.