### PR TITLE
Fix doxy2swig.py IndexError: list index out of range

### DIFF
--- a/doc/doxy2swig.py
+++ b/doc/doxy2swig.py
@@ -299,7 +299,10 @@ class Doxy2SWIG:
             name = first['name'].firstChild.data
 
             for n in node.getElementsByTagName('param'):
-              arg_type = n.getElementsByTagName('type')[0]
+              elts = n.getElementsByTagName('type')
+              if len(elts) == 0:
+                  continue
+              arg_type = elts[0]
               ref = self.get_specific_nodes(arg_type, ('ref'))
               if 'ref' in ref:
                 type_name = ref['ref'].firstChild.data


### PR DESCRIPTION
Fixes the following error in doxy2swig where arg_type is an empty list:
```
/usr/bin/python ./doxy2swig.py -n xml/index.xml pydoc.i
parsing file: xml/cmd__ln_8h.xml
Traceback (most recent call last):
  File "./doxy2swig.py", line 488, in <module>
    main()
  File "./doxy2swig.py", line 484, in main
    convert(args[0], args[1], not options.func_def, options.quiet)
  File "./doxy2swig.py", line 463, in convert
    p.generate()
  File "./doxy2swig.py", line 123, in generate
    self.parse(self.xmldoc)
  File "./doxy2swig.py", line 132, in parse
    pm(node)
  File "./doxy2swig.py", line 162, in parse_Element
    handlerMethod(node)
  File "./doxy2swig.py", line 413, in do_doxygenindex
    p.generate()
  File "./doxy2swig.py", line 123, in generate
    self.parse(self.xmldoc)
  File "./doxy2swig.py", line 132, in parse
    pm(node)
  File "./doxy2swig.py", line 164, in parse_Element
    self.generic_parse(node)
  File "./doxy2swig.py", line 209, in generic_parse
    self.parse(n)
  File "./doxy2swig.py", line 132, in parse
    pm(node)
  File "./doxy2swig.py", line 162, in parse_Element
    handlerMethod(node)
  File "./doxy2swig.py", line 248, in do_compounddef
    self.parse(n)
  File "./doxy2swig.py", line 132, in parse
    pm(node)
  File "./doxy2swig.py", line 162, in parse_Element
    handlerMethod(node)
  File "./doxy2swig.py", line 356, in do_sectiondef
    self.generic_parse(node)
  File "./doxy2swig.py", line 209, in generic_parse
    self.parse(n)
  File "./doxy2swig.py", line 132, in parse
    pm(node)
  File "./doxy2swig.py", line 162, in parse_Element
    handlerMethod(node)
  File "./doxy2swig.py", line 302, in do_memberdef
    arg_type = n.getElementsByTagName('type')[0]
IndexError: list index out of range
```
I have python 3.8, swig 4.0.1, doxygen 1.8.17