### PR TITLE
Make use of stdbool.h when generating Python interface

### DIFF
--- a/swig/sphinxbase.i
+++ b/swig/sphinxbase.i
@@ -79,9 +79,7 @@ negative error code."
 %begin %{
 
 #ifndef __cplusplus
-typedef int bool;
-#define true 1
-#define false 0
+#include <stdbool.h>
 #endif
 
 #include <sphinxbase/cmd_ln.h>


### PR DESCRIPTION
It seems building sphinxbase does not work with Python's 3.11
series. Trying to compile fails with this error:

In file included from /usr/include/python3.11/cpython/pystate.h:5,
                 from /usr/include/python3.11/pystate.h:135,
                 from /usr/include/python3.11/Python.h:76,
                 from sphinxbase_wrap.c:11:
sphinxbase_wrap.c:16:13: error: two or more data types in declaration specifiers
   16 | typedef int bool;
      |             ^~~~
sphinxbase_wrap.c:16:1: warning: useless type name in empty declaration
   16 | typedef int bool;
      | ^~~~~~~

My guess is that one of the Python header files started including
stdbool.h, and thus the type bool conflicts with the name bool in:

typedef int bool;

The offending code is generated using swig.

This commit removes the definition of bool and instead includes
stdbool.h to make use of the system definition.

Signed-off-by: W. Michael Petullo <mike@flyn.org>